### PR TITLE
Fix post-install script, ensure it's compatible between different shells in distros

### DIFF
--- a/easyWSL/post-install.sh
+++ b/easyWSL/post-install.sh
@@ -35,18 +35,19 @@ fi
 add_user()
 {
   echo "Creating the user account ..."
-  read -p "Username: " USERNAME
+  printf "Username: "
+  read -r USERNAME
   if command -v bash > /dev/null 2>&1
   then
     USER_SHELL="/bin/bash"
   else
     USER_SHELL="/bin/sh"
   fi
-  useradd -m -s $USER_SHELL $USERNAME
-  while ! passwd $USERNAME; do
+  useradd -m -s "$USER_SHELL" "$USERNAME"
+  while ! passwd "$USERNAME"; do
     echo Try again.
   done
-  printf "$USERNAME ALL=(ALL:ALL) ALL" >> /etc/sudoers
+  printf "%s ALL=(ALL:ALL) ALL" "$USERNAME" >> /etc/sudoers
   printf "%s\n" "[user]" "default=$USERNAME" >> /etc/wsl.conf
 }
 
@@ -67,8 +68,8 @@ chmod 755 /bin/su
 chmod u+s /bin/su
 
 while true; do
-  echo -n "Do you want to create a new user with administrator privileges? [y/n]: "
-  read answer
+  printf "Do you want to create a new user with administrator privileges? [y/n]: "
+  read -r answer
   if [ "$answer" != "${answer#[Yy]}" ]; then
     add_user
     break

--- a/easyWSL/post-install.sh
+++ b/easyWSL/post-install.sh
@@ -36,7 +36,13 @@ add_user()
 {
   echo "Creating the user account ..."
   read -p "Username: " USERNAME
-  useradd -m -s /bin/bash $USERNAME
+  if command -v bash > /dev/null 2>&1
+  then
+    USER_SHELL="/bin/bash"
+  else
+    USER_SHELL="/bin/sh"
+  fi
+  useradd -m -s $USER_SHELL $USERNAME
   while ! passwd $USERNAME; do
     echo Try again.
   done
@@ -65,7 +71,9 @@ while true; do
   read answer
   if [ "$answer" != "${answer#[Yy]}" ]; then
     add_user
+    break
   else
     set_root_passwd
+    break
   fi
 done

--- a/easyWSL/post-install.sh
+++ b/easyWSL/post-install.sh
@@ -1,34 +1,35 @@
+#!/usr/bin/env sh
 echo "Upgrading the system ..."
-if command -v apt &> /dev/null; then
-  apt-get -y update &> /dev/null
-  apt-get -y install sudo &> /dev/null
+if command -v apt > /dev/null 2>&1; then
+  apt-get -y update > /dev/null 2>&1
+  apt-get -y install sudo > /dev/null 2>&1
 fi
 
-if command -v pacman &> /dev/null; then
-  pacman -Syu --noconfirm &> /dev/null
-  pacman -S --noconfirm sudo &> /dev/null
+if command -v pacman > /dev/null 2>&1; then
+  pacman -Syu --noconfirm > /dev/null 2>&1
+  pacman -S --noconfirm sudo > /dev/null 2>&1
 fi
 
-if command -v apk &> /dev/null; then
-  apk update &> /dev/null
-  apk add sudo &> /dev/null
+if command -v apk > /dev/null 2>&1; then
+  apk update > /dev/null 2>&1
+  apk add sudo shadow > /dev/null 2>&1
 fi
 
-if command -v rpm &> /dev/null; then
-  rpm -U &> /dev/null
-  rpm -i sudo &> /dev/null
+if command -v rpm > /dev/null 2>&1; then
+  rpm -U > /dev/null 2>&1
+  rpm -i sudo > /dev/null 2>&1
 fi
 
-if command -v xbps &> /dev/null; then
-  xbps-install -Su &> /dev/null
-  xbps-install sudo &> /dev/null
+if command -v xbps > /dev/null 2>&1; then
+  xbps-install -Su > /dev/null 2>&1
+  xbps-install sudo > /dev/null 2>&1
 fi
 
-if command -v emerge &> /dev/null; then
-  emaint -a sync &> /dev/null
-  emerge-webrsync &> /dev/null
-  eix-sync &> /dev/null
-  emerge -a sudo &> /dev/null
+if command -v emerge > /dev/null 2>&1; then
+  emaint -a sync > /dev/null 2>&1
+  emerge-webrsync > /dev/null 2>&1
+  eix-sync > /dev/null 2>&1
+  emerge -a sudo > /dev/null 2>&1
 fi
 
 add_user()
@@ -40,7 +41,7 @@ add_user()
     echo Try again.
   done
   printf "$USERNAME ALL=(ALL:ALL) ALL" >> /etc/sudoers
-  printf "%s\n" "[user]" "default=$USERNAME" >> /etc/wsl.conf 
+  printf "%s\n" "[user]" "default=$USERNAME" >> /etc/wsl.conf
 }
 
 set_root_passwd()
@@ -60,10 +61,11 @@ chmod 755 /bin/su
 chmod u+s /bin/su
 
 while true; do
-  read -p "Do you want to create a new user with administrator privileges? [y/n]: " yn
-  case $yn in
-    [Yy]* ) add_user; break;;
-    [Nn]* ) set_root_passwd; break;;
-  esac
+  echo -n "Do you want to create a new user with administrator privileges? [y/n]: "
+  read answer
+  if [ "$answer" != "${answer#[Yy]}" ]; then
+    add_user
+  else
+    set_root_passwd
+  fi
 done
-


### PR DESCRIPTION
The post-install script use Bash-specific features. This PR should cover most of the issues found while tinkering with the easyWSL.
Additionally, the post-install script detects if Bash is installed on the system rather than setting Bash as a user shell even if it wasn't available — this resulted in a broken user. 

Closes #17 